### PR TITLE
eyes.inspect([null]) throws TypeError: Object.keys called on non-object. fixed.

### DIFF
--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -148,7 +148,7 @@ function stringifyString (str, options) {
 function stringifyArray(ary, options, level) {
     var out = [];
     var pretty = options.pretty && (ary.length > 4 || ary.some(function (o) {
-        return (typeof(o) === 'object' && Object.keys(o).length > 0) ||
+        return (o && typeof(o) === 'object' && Object.keys(o).length > 0) ||
                (Array.isArray(o) && o.length > 0);
     }));
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';

--- a/test/eyes-test.js
+++ b/test/eyes-test.js
@@ -53,3 +53,6 @@ sys.puts(inspect('something', "something"));
 sys.puts(inspect("something else"));
 
 sys.puts(inspect(["no color"], null, { styles: false }));
+
+
+eyes.inspect([null])


### PR DESCRIPTION
wasn't checking if something that was typeof 'object' wasn't null.
