### PR TITLE
0.6 compatibility

### DIFF
--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -28,6 +28,7 @@ eyes.defaults = {
     },
     pretty: true,             // Indent object literals
     hideFunctions: false,
+    showHidden: false,
     stream: process.stdout,
     maxLength: 2048           // Truncate output if longer
 };
@@ -176,7 +177,8 @@ function stringifyObject(obj, options, level) {
                                     Object.keys(obj).some(function (k) { return typeof(obj[k]) === 'object' }));
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
-    Object.keys(obj).forEach(function (k) {
+    var keys = options.showHidden ? Object.keys(obj) : Object.getOwnPropertyNames(obj);
+    keys.forEach(function (k) {
         if (obj.hasOwnProperty(k) && !(obj[k] instanceof Function && options.hideFunctions)) {
             out.push(eyes.stylize(k, options.styles.key, options.styles) + ': ' +
                      stringify(obj[k], options));

--- a/test/eyes-test.js
+++ b/test/eyes-test.js
@@ -1,4 +1,4 @@
-var sys = require('sys');
+var util = require('util');
 var eyes = require('../lib/eyes');
 
 eyes.inspect({
@@ -49,7 +49,7 @@ eyes.inspect({
 
 var inspect = eyes.inspector({ stream: null });
 
-sys.puts(inspect('something', "something"));
-sys.puts(inspect("something else"));
+util.puts(inspect('something', "something"));
+util.puts(inspect("something else"));
 
-sys.puts(inspect(["no color"], null, { styles: false }));
+util.puts(inspect(["no color"], null, { styles: false }));


### PR DESCRIPTION
Changes:
- add `showHidden` option (mainly for inspecting errors, which are enumerable as per ES5; [reference](https://github.com/joyent/node/wiki/API-changes-between-v0.4-and-v0.6))
- `s/sys/util/g` in example code
