### PR TITLE
[dist] Remove empty `dependencies` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "author"        : "Alexis Sellier <self@cloudhead.net>",
   "contributors"  : [{ "name": "Charlie Robbins", "email": "charlie@nodejitsu.com" }],
   "licenses"      : ["MIT"],
-  "dependencies"  : [],
   "main"          : "./lib/eyes",
   "version"       : "0.1.7",
   "scripts"       : { "test": "node test/*-test.js" },


### PR DESCRIPTION
`npm` displays a warning.

```
npm WARN eyes@0.1.7 dependencies field should be hash of <name>:<version-range> pairs
```

[![Warning](http://i.imgur.com/4KhWa.png)](http://travis-ci.org/#!/flatiron/director/jobs/506490/L48)
