### PR TITLE
Added support for truncation of objects, arrays, strings

### DIFF
--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -116,7 +116,8 @@ function stringify(obj, options) {
     result = (function (obj) {
         switch (typeOf(obj)) {
             case "string"   : obj = stringifyString(obj.indexOf("'") === -1 ? "'" + obj + "'"
-                                                                            : '"' + obj + '"');
+                                                                            : '"' + obj + '"'
+                                                                            , options);
                               return stylize(obj, 'string');
             case "regexp"   : return stylize('/' + obj.source + '/', 'regexp');
             case "number"   : return stylize(obj + '',    'number');
@@ -136,11 +137,19 @@ function stringify(obj, options) {
 
 // Escape invisible characters in a string
 function stringifyString (str, options) {
-    return str.replace(/\\/g, '\\\\')
+    result = str.replace(/\\/g, '\\\\')
               .replace(/\n/g, '\\n')
               .replace(/[\u0001-\u001F]/g, function (match) {
                   return '\\0' + match[0].charCodeAt(0).toString(8);
               });
+
+    // Truncate the string if a maximum length is configured
+    if(options.maxStringLength && result.length > options.maxStringLength) {
+        result = result.substr(0, Math.min(result.length, options.maxStringLength - 3));
+        result += '...'
+    }
+
+    return result;
 }
 
 // Convert an array to a string, such as [1, 2, 3].
@@ -154,8 +163,14 @@ function stringifyArray(ary, options, level) {
     }));
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
-    for (var i = 0; i < ary.length; i++) {
+    length = options.maxArrayKeys ? Math.min(ary.length, options.maxArrayKeys -1) : ary.length;
+    for (var i = 0; i < length; i++) {
         out.push(stringify(ary[i], options));
+    }
+
+    // Truncate the array if the maximum array length is specified
+    if(options.maxArrayLength && length > 0) {
+        out.push('<<Array truncated>>');
     }
 
     if (out.length === 0) {
@@ -178,6 +193,15 @@ function stringifyObject(obj, options, level) {
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
     var keys = options.showHidden ? Object.keys(obj) : Object.getOwnPropertyNames(obj);
+
+    // Prepend the output with a phony key that shows that the object has been truncated
+    if(options.maxObjectKeys) {
+        length = Math.min(keys.length, options.maxObjectKeys - 1);
+        if(length < keys.length) {
+            keys.splice(length - 1, keys.length - length);
+            out.push(eyes.stylize('__truncated__', options.styles.key, options.styles) + ': <<Object truncated>>');
+        }
+    }
     keys.forEach(function (k) {
         if (Object.prototype.hasOwnProperty.call(obj, k) 
           && !(obj[k] instanceof Function && options.hideFunctions)) {
@@ -233,4 +257,3 @@ function merge(/* variable args */) {
     });
     return target;
 }
-


### PR DESCRIPTION
Array entries, object properties and string length can be configured to
be truncated so the log output stays clean. By default no truncation takes place. 
Pay attention however: the truncation may hide logging elements you don't want to miss.
This feature is useful for us because we use eyes.js in combination with a winston logger to rewrite the meta object of log messages so it doesn't display endless arrays etc.
