### PR TITLE
Added support for truncation of Strings, Arrays and Objects

### DIFF
--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -116,7 +116,8 @@ function stringify(obj, options) {
     result = (function (obj) {
         switch (typeOf(obj)) {
             case "string"   : obj = stringifyString(obj.indexOf("'") === -1 ? "'" + obj + "'"
-                                                                            : '"' + obj + '"');
+                                                                            : '"' + obj + '"'
+                                                                            , options);
                               return stylize(obj, 'string');
             case "regexp"   : return stylize('/' + obj.source + '/', 'regexp');
             case "number"   : return stylize(obj + '',    'number');
@@ -136,11 +137,19 @@ function stringify(obj, options) {
 
 // Escape invisible characters in a string
 function stringifyString (str, options) {
-    return str.replace(/\\/g, '\\\\')
+    result = str.replace(/\\/g, '\\\\')
               .replace(/\n/g, '\\n')
               .replace(/[\u0001-\u001F]/g, function (match) {
                   return '\\0' + match[0].charCodeAt(0).toString(8);
               });
+
+    // Truncate the string if a maximum length is configured
+    if(options.maxStringLength && result.length > options.maxStringLength) {
+        result = result.substr(0, Math.min(result.length, options.maxStringLength - 3));
+        result += '...'
+    }
+
+    return result;
 }
 
 // Convert an array to a string, such as [1, 2, 3].
@@ -154,8 +163,14 @@ function stringifyArray(ary, options, level) {
     }));
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
-    for (var i = 0; i < ary.length; i++) {
+    length = options.maxArrayKeys ? Math.min(ary.length, options.maxArrayKeys -1) : ary.length;
+    for (var i = 0; i < length; i++) {
         out.push(stringify(ary[i], options));
+    }
+
+    // Truncate the array if the maximum array length is specified
+    if(options.maxArrayLength && length > 0) {
+        out.push('<<Array truncated>>');
     }
 
     if (out.length === 0) {
@@ -178,6 +193,15 @@ function stringifyObject(obj, options, level) {
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
     var keys = options.showHidden ? Object.keys(obj) : Object.getOwnPropertyNames(obj);
+
+    // Prepend the output with a phony key that shows that the object has been truncated
+    if(options.maxObjectKeys) {
+        length = Math.min(keys.length, options.maxObjectKeys - 1);
+        if(length < keys.length) {
+            keys.splice(length - 1, keys.length - length);
+            out.push(eyes.stylize('__truncated__', options.styles.key, options.styles) + ': <<Object truncated>>');
+        }
+    }
     keys.forEach(function (k) {
         if (Object.prototype.hasOwnProperty.call(obj, k) 
           && !(obj[k] instanceof Function && options.hideFunctions)) {
@@ -233,4 +257,3 @@ function merge(/* variable args */) {
     });
     return target;
 }
-

--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -163,14 +163,14 @@ function stringifyArray(ary, options, level) {
     }));
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
-    length = options.maxArrayKeys ? Math.min(ary.length, options.maxArrayKeys -1) : ary.length;
+    length = options.maxArrayLength ? Math.min(ary.length, options.maxArrayLength -1) : ary.length;
     for (var i = 0; i < length; i++) {
         out.push(stringify(ary[i], options));
     }
 
     // Truncate the array if the maximum array length is specified
     if(options.maxArrayLength && length > 0) {
-        out.push('<<Array truncated>>');
+        out.push('<<truncated>>');
     }
 
     if (out.length === 0) {

--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -163,13 +163,13 @@ function stringifyArray(ary, options, level) {
     }));
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
-    length = options.maxArrayLength ? Math.min(ary.length, options.maxArrayLength -1) : ary.length;
+    var length = options.maxArrayLength ? Math.min(ary.length, options.maxArrayLength - 1) : ary.length;
     for (var i = 0; i < length; i++) {
         out.push(stringify(ary[i], options));
     }
 
-    // Truncate the array if the maximum array length is specified
-    if(options.maxArrayLength && length > 0) {
+    // Add a special String if the array was truncated
+    if(options.maxArrayLength && length < ary.length) {
         out.push('<<truncated>>');
     }
 

--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -136,7 +136,7 @@ function stringify(obj, options) {
 };
 
 // Escape invisible characters in a string
-function stringifyString (str, options) {
+function stringifyString(str, options) {
     result = str.replace(/\\/g, '\\\\')
               .replace(/\n/g, '\\n')
               .replace(/[\u0001-\u001F]/g, function (match) {
@@ -144,9 +144,10 @@ function stringifyString (str, options) {
               });
 
     // Truncate the string if a maximum length is configured
-    if(options.maxStringLength && result.length > options.maxStringLength) {
-        result = result.substr(0, Math.min(result.length, options.maxStringLength - 3));
-        result += '...'
+    var truncate = options.hasOwnProperty('maxStringLength') && options.maxStringLength >= 0;
+    if(truncate && result.length > options.maxStringLength) {
+        var length = Math.min(result.length, options.maxStringLength - 3);
+        result = (length <= 0 ? "'" : '') + result.substr(0, length) + "...'";
     }
 
     return result;
@@ -163,13 +164,15 @@ function stringifyArray(ary, options, level) {
     }));
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
-    var length = options.maxArrayLength ? Math.min(ary.length, options.maxArrayLength - 1) : ary.length;
+    var truncate = options.hasOwnProperty('maxArrayLength') && options.maxArrayLength >= 0;
+
+    var length = truncate ? Math.min(ary.length, options.maxArrayLength) : ary.length;
     for (var i = 0; i < length; i++) {
         out.push(stringify(ary[i], options));
     }
 
     // Add a special String if the array was truncated
-    if(options.maxArrayLength && length < ary.length) {
+    if(length < ary.length) {
         out.push('<<truncated>>');
     }
 
@@ -193,14 +196,11 @@ function stringifyObject(obj, options, level) {
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
     var keys = options.showHidden ? Object.keys(obj) : Object.getOwnPropertyNames(obj);
-    var truncate = options.maxObjectKeys && keys.length > (options.maxObjectKeys - 1);
+    var truncate = options.hasOwnProperty('maxObjectKeys') && options.maxObjectKeys >= 0;
 
-    // Slice the keys to the maximum length
-    if (truncate) {
-        keys = keys.slice(0, (options.maxObjectKeys - 1));
-    }
-
-    keys.forEach(function (k) {
+    // Slice the keys to the maximum length if they exceed the maxObjectKeys option
+    var includeKeys = (truncate) ? keys.slice(0, options.maxObjectKeys) : keys;
+    includeKeys.forEach(function (k) {
         if (Object.prototype.hasOwnProperty.call(obj, k)
           && !(obj[k] instanceof Function && options.hideFunctions)) {
             out.push(eyes.stylize(k, options.styles.key, options.styles) + ': ' +
@@ -209,7 +209,7 @@ function stringifyObject(obj, options, level) {
     });
 
     // Append a special String if the Object was truncated
-    if (truncate) {
+    if (includeKeys.length < keys.length) {
         out.push(eyes.stylize('<<truncated>>', options.styles.key, options.styles));
     }
 

--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -115,10 +115,10 @@ function stringify(obj, options) {
 
     result = (function (obj) {
         switch (typeOf(obj)) {
-            case "string"   : obj = stringifyString(obj.indexOf("'") === -1 ? "'" + obj + "'"
-                                                                            : '"' + obj + '"'
-                                                                            , options);
-                              return stylize(obj, 'string');
+            case "string"   : obj = stringifyString(obj, options);
+                              return stylize(obj.indexOf("'") === -1 ? "'" + obj + "'"
+                                                                     : '"' + obj + '"'
+                                                                     , 'string');
             case "regexp"   : return stylize('/' + obj.source + '/', 'regexp');
             case "number"   : return stylize(obj + '',    'number');
             case "function" : return options.stream ? stylize("Function", 'other') : '[Function]';
@@ -147,7 +147,7 @@ function stringifyString(str, options) {
     var truncate = options.hasOwnProperty('maxStringLength') && options.maxStringLength >= 0;
     if(truncate && result.length > options.maxStringLength) {
         var length = Math.min(result.length, options.maxStringLength - 3);
-        result = (length <= 0 ? "'" : '') + result.substr(0, length) + "...'";
+        result = result.substr(0, length) + "...";
     }
 
     return result;

--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -193,22 +193,25 @@ function stringifyObject(obj, options, level) {
     var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
     var keys = options.showHidden ? Object.keys(obj) : Object.getOwnPropertyNames(obj);
+    var truncate = options.maxObjectKeys && keys.length > (options.maxObjectKeys - 1);
 
-    // Prepend the output with a phony key that shows that the object has been truncated
-    if(options.maxObjectKeys) {
-        length = Math.min(keys.length, options.maxObjectKeys - 1);
-        if(length < keys.length) {
-            keys.splice(length - 1, keys.length - length);
-            out.push(eyes.stylize('__truncated__', options.styles.key, options.styles) + ': <<Object truncated>>');
-        }
+    // Slice the keys to the maximum length
+    if (truncate) {
+        keys = keys.slice(0, (options.maxObjectKeys - 1));
     }
+
     keys.forEach(function (k) {
-        if (Object.prototype.hasOwnProperty.call(obj, k) 
+        if (Object.prototype.hasOwnProperty.call(obj, k)
           && !(obj[k] instanceof Function && options.hideFunctions)) {
             out.push(eyes.stylize(k, options.styles.key, options.styles) + ': ' +
                      stringify(obj[k], options));
         }
     });
+
+    // Append a special String if the Object was truncated
+    if (truncate) {
+        out.push(eyes.stylize('<<truncated>>', options.styles.key, options.styles));
+    }
 
     if (out.length === 0) {
         return '{}';

--- a/test/eyes-test.js
+++ b/test/eyes-test.js
@@ -54,3 +54,44 @@ util.puts(inspect('something', "something"));
 util.puts(inspect("something else"));
 
 util.puts(inspect(["no color"], null, { styles: false }));
+
+eyes.inspect('This String is truncated completely', 'String truncated completely', { maxStringLength: 0 });
+eyes.inspect('This String is way too long', 'String too long', { maxStringLength: 12 });
+eyes.inspect('This String is exactly right', 'String exactly short enough', { maxStringLength: 29 });
+eyes.inspect('This String is short enough', 'String is shorter', { maxStringLength: 30 });
+
+eyes.inspect(['a', 'b', 'c'], 'Array short enough', { maxArrayLength: 4 });
+eyes.inspect(['a', 'b', 'c'], 'Array exactly short enough', { maxArrayLength: 3 });
+eyes.inspect(['a', 'b', 'c'], 'Array length too long', { maxArrayLength: 2 });
+eyes.inspect(['a', 'b', 'c'], 'Array length too long', { maxArrayLength: 1 });
+eyes.inspect(['a', 'b', 'c'], 'Array trunctated completely', { maxArrayLength: 0 });
+
+eyes.inspect({ 'a': 'A', 'b': 'B', 'c': 'C' }, 'Object short enough', { maxObjectKeys: 4 });
+eyes.inspect({ 'a': 'A', 'b': 'B', 'c': 'C' }, 'Object exactly short enough', { maxObjectKeys: 3 });
+eyes.inspect({ 'a': 'A', 'b': 'B', 'c': 'C' }, 'Object has too many keys', { maxObjectKeys: 2 });
+eyes.inspect({ 'a': 'A', 'b': 'B', 'c': 'C' }, 'Object has too many keys', { maxObjectKeys: 1 });
+eyes.inspect({ 'a': 'A', 'b': 'B', 'c': 'C' }, 'Object truncated completely', { maxObjectKeys: 0 });
+
+eyes.inspect(1234567890, 'Number too long', { maxStringLength: 6 });
+
+eyes.inspect({
+    name:  "Something about ogres",
+    story: "Once upon a time, in a land far far away.",
+    tags: [
+        "ogres",
+        "donkey",
+        "fairytail",
+        "prince",
+        "evil"
+    ],
+    related: [
+        "A story about an angry prince and his quest to rule the land"
+    ],
+    link: "http://farfaraway.ff"
+},
+'Combination truncated',
+{
+    maxObjectKeys: 4,
+    maxArrayLength: 2,
+    maxStringLength: 39
+});


### PR DESCRIPTION
> This is a replacement Pull Request for [pull/18](https://github.com/cloudhead/eyes.js/pull/18)

Added support for limiting the output of Strings, Arrays and Objects. This is done with three optional parameters: `maxStringLength`, `maxArrayLength` and `maxObjectKeys`. This will truncate the output to length to keep the output limited (e.g. for logging).

By default no truncation takes place. Pay attention however: truncation may hide certain elements you may want to display.

Tests cases are included in test/eyes-test.js.
